### PR TITLE
Add New Feature: select were the link is opened (in new tab or in current tab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A React component that renders beautiful, fully-customizable link previews.
 
 ![Demo](demo.gif)
-[![npm version](https://badge.fury.io/js/%40dhaiwat10%2Freact-link-preview.svg)](https://badge.fury.io/js/%40dhaiwat10%2Freact-link-preview) 
-![package downloads](https://img.shields.io/npm/dt/@dhaiwat10/react-link-preview) 
+[![npm version](https://badge.fury.io/js/%40dhaiwat10%2Freact-link-preview.svg)](https://badge.fury.io/js/%40dhaiwat10%2Freact-link-preview)
+![package downloads](https://img.shields.io/npm/dt/@dhaiwat10/react-link-preview)
 ![CI](https://img.shields.io/github/workflow/status/dhaiwat10/react-link-preview/CI)
 
 <a href="https://codesandbox.io/s/rlp-demo-90e1x?file=/src/App.js" target="_blank">Demo</a>
@@ -120,6 +120,7 @@ Length of the description in the card. (number of characters)
 ### `borderRadius?` (string or number)
 
 Border radius of the card.
+
 <hr />
 
 ### `imageHeight?` (string or number)
@@ -131,6 +132,12 @@ Height of the image.
 ### `textAlign?` ( _left_, _right_ or _center_)
 
 Alignment of the text.
+
+<hr />
+
+### `openInNewTab?` (boolean)
+
+Where the link is opened (new tab or current tab).
 
 <hr />
 

--- a/src/components/LinkPreview/LinkPreview.tsx
+++ b/src/components/LinkPreview/LinkPreview.tsx
@@ -22,6 +22,7 @@ export interface LinkPreviewProps {
   borderColor?: string;
   showLoader?: boolean;
   customLoader?: JSX.Element[] | JSX.Element | null;
+  openInNewTab?: boolean;
 }
 
 export interface APIResponse {
@@ -49,6 +50,7 @@ export const LinkPreview: React.FC<LinkPreviewProps> = ({
   borderColor = '#ccc',
   showLoader = true,
   customLoader = null,
+  openInNewTab = true,
 }) => {
   const _isMounted = useRef(true);
   const [metadata, setMetadata] = useState<APIResponse | null>();
@@ -94,7 +96,8 @@ export const LinkPreview: React.FC<LinkPreviewProps> = ({
   const { image, description, title, siteName, hostname } = metadata;
 
   const onClick = () => {
-    window.open(url, '_blank');
+    const browserTarget = openInNewTab ? '_blank' : '_self';
+    window.open(url, browserTarget);
   };
 
   return (


### PR DESCRIPTION
I'm using this package for a personal website and I would like to be able to select were the link is opened.

I added the `openInNewTab` prop for this. For compatibility reasons, I left `true` as default because that was the old way the component was working (for not surprises).

I also added the option to the Readme documentation.

Please take a look and if you find it interesting post a new version :).