### PR TITLE
Updated react-loading-skeleton to remove the reliance on @emotion/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "module": "index.esm.js",
   "types": "index.d.ts",
   "dependencies": {
-    "react-loading-skeleton": "^2.2.0"
+    "react-loading-skeleton": "^3.1.0"
   },
   "peerDependencies": {
     "react": "^16.0.0 || ^17.0.0",

--- a/src/components/LinkPreview/Skeleton.tsx
+++ b/src/components/LinkPreview/Skeleton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import LoadingSkeleton from 'react-loading-skeleton';
 
 import './skeleton.scss';
+import 'react-loading-skeleton/dist/skeleton.css';
 
 interface SkeletonProps {
   width?: string | number;


### PR DESCRIPTION
Simply updated the version of react-loading-skeleton in package.json to 3.1.0

Version 3 and up of this library don't rely on emotion for styling, though they do require you to import a CSS file into the app/library. I don't have much experience with CSS bundling and libraries so any input is appreciated (I don't know if I should put the import into Skeleton.tsx or the sass file. For now, the CSS is imported in Skeleton.tsx.). There aren't any breaking changes that would affect our usage.