### PR TITLE
fix: Remove !important on Container:hover

### DIFF
--- a/src/components/LinkPreview/linkPreview.scss
+++ b/src/components/LinkPreview/linkPreview.scss
@@ -14,7 +14,7 @@ $secondary: rgb(100, 100, 100);
   height: fit-content;
 
   &:hover {
-    background-color: rgb(250, 250, 250) !important;
+    background-color: rgb(250, 250, 250);
     cursor: pointer;
   }
 }


### PR DESCRIPTION
The white looks terrible, especially on a dark background, but more importantly (pun intended) the !important makes it annoying as hell to change without needing to fork the repo and make it a custom dependency just for a minor CSS modification